### PR TITLE
Look up method spec by name

### DIFF
--- a/cmd/pontoongen/reghttp.go
+++ b/cmd/pontoongen/reghttp.go
@@ -100,6 +100,15 @@ func (vr *visRegHTTP) litFromExpr(ex ast.Node) *ast.BasicLit {
 		f, _ := astFindFile(vr.pkgReg.Imports[pkg.Path()], obj.Pos())
 
 		ecl, _ := astutil.PathEnclosingInterval(f, obj.Pos()-1, obj.Pos())
+
+		specs := ecl[0].(*ast.GenDecl).Specs
+		for i, s := range specs {
+			specName := s.(*ast.ValueSpec).Names[0].Name
+			if specName == v.Sel.Name {
+				return vr.litFromExpr(specs[i])
+			}
+		}
+
 		return vr.litFromExpr(ecl[0].(*ast.GenDecl).Specs[0])
 	case *ast.ValueSpec:
 		return vr.litFromExpr(v.Names[0])

--- a/test/handler.pontoon.go
+++ b/test/handler.pontoon.go
@@ -131,6 +131,122 @@ func (s Handler) OpenAPI() string {
           "tags": [
             "test.Handler"
           ]
+        },
+        "post": {
+          "description": "IterateProducts comment\nIncludes imported package\n",
+          "parameters": [
+            {
+              "description": "PageToken comment\n",
+              "in": "query",
+              "name": "page_token",
+              "schema": {
+                "description": "PageToken comment\n",
+                "type": "string"
+              }
+            },
+            {
+              "description": "Local field\n",
+              "in": "query",
+              "name": "local",
+              "schema": {
+                "description": "Local field\n",
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/test.iterateRequest"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/test2.IterateResponse"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "default": {
+              "description": ""
+            }
+          },
+          "tags": [
+            "test.Handler"
+          ]
+        }
+      },
+      "/v1/products/iterate/create": {
+        "post": {
+          "description": "IterateProducts comment\nIncludes imported package\n",
+          "parameters": [
+            {
+              "description": "PageToken comment\n",
+              "in": "query",
+              "name": "page_token",
+              "schema": {
+                "description": "PageToken comment\n",
+                "type": "string"
+              }
+            },
+            {
+              "description": "Local field\n",
+              "in": "query",
+              "name": "local",
+              "schema": {
+                "description": "Local field\n",
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/test.iterateRequest"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/test2.IterateResponse"
+                  }
+                }
+              },
+              "description": "success"
+            },
+            "default": {
+              "description": ""
+            }
+          },
+          "tags": [
+            "test.Handler"
+          ]
         }
       },
       "/v1/test/return/interface": {

--- a/test/reg.go
+++ b/test/reg.go
@@ -7,7 +7,13 @@ import (
 )
 
 func (h Handler) RegisterHTTP(mux sdesc.HTTPRouter) {
+	// POST
+	mux.MethodFunc(http.MethodPost, "/v1/products/iterate/create", h.iterateProducts)
+	// GET
 	mux.MethodFunc(http.MethodGet, "/v1/products/iterate", h.iterateProducts)
+	// Same path as above, different ops
+	mux.MethodFunc(http.MethodPost, "/v1/products/iterate", h.iterateProducts)
+	// Different return types
 	mux.MethodFunc(http.MethodGet, "/v1/test/return/return-nothing", h.zeroReturn)
 	mux.MethodFunc(http.MethodGet, "/v1/test/return/interface", h.ifaceReturn)
 	mux.MethodFunc(http.MethodGet, "/v1/test/return/interface-any", h.ifaceReturnAny)


### PR DESCRIPTION
The AST scope seems to include the entire const block for HTTP
methods. By default, we take the one at index 0, which is GET

Iterating over the specs in the scope lets us compare the spec name
to the selector name so we get the right one

If not found, we'll return the first spec so the fallback is the same
behaviour we had previously